### PR TITLE
fix(argo-cd): Added openshift route options to values.yaml

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.26.6
+version: 3.26.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Make argocd-server /home/argocd/.aws writeable when using readOnlyRootFilesystem=false security context"
+    - "[Fixed]: Added Openshift Route values that were previously included in Route.yaml directives."

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -449,8 +449,11 @@ NAME: my-release
 | server.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | server.replicas | int | `1` | The number of server pods to run |
 | server.resources | object | `{}` | Resource limits and requests for the Argo CD server |
-| server.route.enabled | bool | `false` | Enable a OpenShift route for the Argo CD server |
-| server.route.hostname | string | `""` | Hostname of OpenShift route |
+| server.route.enabled | bool | `false` | Enable an OpenShift Route for the Argo CD server |
+| server.route.annotations | object | `{}` | Openshift Route annotations |
+| server.route.hostname | string | `""` | Hostname of OpenShift Route |
+| server.route.termination_type | string | `"Passthrough"` | Openshift Route termination type |
+| server.route.termination_policy| string | `"None"` | Openshift Route termination policy |
 | server.service.annotations | object | `{}` | Server service annotations |
 | server.service.externalIPs | list | `[]` | Server service external IPs |
 | server.service.externalTrafficPolicy | string | `""` | Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -999,10 +999,16 @@ server:
   # Find your domain with: kubectl describe --namespace=openshift-ingress-operator ingresscontroller/default | grep Domain:
   # If 'hostname' is an empty string "" OpenShift will create a hostname for you.
   route:
-    # -- Enable a OpenShift route for the Argo CD server
+    # -- Enable an OpenShift Route for the Argo CD server
     enabled: false
-    # -- Hostname of OpenShift route
+    # -- Openshift Route annotations
+    annotations: {}
+    # -- Hostname of OpenShift Route
     hostname: ""
+    # -- Termination type of Openshift Route
+    termination_type: Passthrough
+    # -- Termination policy of Openshift Route
+    termination_policy: None
 
   # -- Manage ArgoCD configmap (Declarative Setup)
   ## Ref: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/argocd-cm.yaml


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
